### PR TITLE
fix: keep mobile map visible when stale banner is hidden

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -80,9 +80,11 @@ a:hover { text-decoration: underline; }
 }
 
 #map {
+  grid-row: 3;
   position: relative;
   width: 100%;
   height: 100%;
+  min-height: 0;
   background: var(--bg);
 }
 


### PR DESCRIPTION
# Fix mobile map layout

## Summary

- Fix the mobile map going blank after PR #4 by explicitly placing `#map`
  in the visible app grid row.
- Keep the map grid child shrink-safe with `min-height: 0`.

## Root cause

PR #4 added a hidden stale-data banner between the top bar and map. Because
`[hidden]` removes the banner from grid layout, CSS auto-placement put `#map`
into the zero-height second row (`auto auto 1fr`), leaving Leaflet with a
`height: 0` container on mobile.

## Validation

- `node --check assets/app.js`
- `python3 -m json.tool masternodes.json`
- `python3 -m json.tool masternodes_geolocations.json`
- `python3 -m py_compile update_geolocations.py`
- Local iPhone 14 Pro emulation against `python3 -m http.server`:
  - before fix: live site `#map` measured `390×0`
  - after fix: local branch `#map` measured `393×601`, with tiles and marker
    clusters present
- Pre-PR code review gate: `ship`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the map section’s layout so it fits correctly within the app grid.
  * Prevented the map from forcing extra height, allowing it to shrink properly in its container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->